### PR TITLE
Add "answered" to MMLU analysis

### DIFF
--- a/visualization/MMLU/visualize.py
+++ b/visualization/MMLU/visualize.py
@@ -33,6 +33,7 @@ project = zeno_client.create_project(
     public=True,
     metrics=[
         ZenoMetric(name="Accuracy", type="mean", columns=["correct"]),
+        ZenoMetric(name="Answered", type="mean", columns=["output_length"]),
     ],
 )
 


### PR DESCRIPTION
@yuzc19 this adds a new metric that averages over the output length for MMLU. Because in MMLU, the output length is 1 if the model answers, and 0 otherwise, this will allow us to easily analyze if there are slices where the model refuses to answer questions more often.

Anecdotally, this seems to be the case on the `human_sexuality` slice, but I'd like to check more systematically.